### PR TITLE
Updated requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To use this code you need to install some packages and libraries which will enab
 
 0.  sudo apt-get install build-essential
 
-1.  sudo apt-get install libsdl-image1.2 libsdl-image1.2-dev guile-1.8 guile-1.8-dev libsdl1.2debian-all libart-2.0-dev libaudiofile-dev libesd0-dev libdirectfb-dev libdirectfb-extra libfreetype6-dev libxext-dev x11proto-xext-dev libfreetype6 libaa1 libaa1-dev libslang2-dev libasound2 libasound2-dev
+1.  sudo apt-get install libsdl-image1.2 libsdl-image1.2-dev guile-1.8 guile-1.8-dev libsdl1.2debian:i386 libsdl1.2debian libart-2.0-dev libaudiofile-dev libesd0-dev libdirectfb-dev libdirectfb-extra libfreetype6-dev libxext-dev x11proto-xext-dev libfreetype6 libaa1 libaa1-dev libslang2-dev libasound2 libasound2-dev
 
 2.  Download [libgraph] (http://download.savannah.gnu.org/releases/libgraph/libgraph-1.0.2.tar.gz).
 


### PR DESCRIPTION
libsdl1.2debian-all  is no more available to install.  Instead of that we can install  libsdl1.2debian:i386 libsdl1.2debian
